### PR TITLE
feat: add CustomerBookingLink CD entity type and interface

### DIFF
--- a/src/types/FirstToFly/CustomerBookingLink.ts
+++ b/src/types/FirstToFly/CustomerBookingLink.ts
@@ -1,0 +1,22 @@
+import type { CDEntity } from "../entity";
+
+
+export interface FTFCustomerBookingLink extends CDEntity {
+  tenantOID: string;
+  bookingOID: string;
+  expiresAt: string | null;
+  isActive: boolean;
+  accessCount: number;
+  failedAccessCount: number;
+  lastAccessedAt: string | null;
+  customerEmail: string | null;
+  isVerified: boolean;
+  verifiedAt: string | null;
+  metadata: Record<string, unknown> | null;
+  qrCodeUrl?: string;
+  accessUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+  updatedBy: string;
+}

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -9,6 +9,7 @@ import type { FTFBudget } from "./FirstToFly/Budget";
 import type { FTFBudgetEntry } from "./FirstToFly/BudgetEntry";
 import type { FTFCostingItem } from "./FirstToFly/CostingItem";
 import type { FTFCostingTemplate } from "./FirstToFly/CostingTemplate";
+import type { FTFCustomerBookingLink } from "./FirstToFly/CustomerBookingLink";
 import type { FTFDepartment } from "./FirstToFly/Department";
 import type { FTFDeposit } from "./FirstToFly/Deposit";
 import type { FTFDesignation } from "./FirstToFly/Designation";
@@ -79,6 +80,7 @@ export type AllEntityField =
   | keyof FTFBudgetEntry
   | keyof FTFCostingItem
   | keyof FTFCostingTemplate
+  | keyof FTFCustomerBookingLink
   | keyof FTFDepartment
   | keyof FTFDeposit
   | keyof FTFDesignation

--- a/src/types/entity.ts
+++ b/src/types/entity.ts
@@ -94,6 +94,9 @@ export enum CDEntityType {
   // PAYMENT AND TRANSACTION
   FTF_PAYMENT_ORDER = "ftf-paymentOrder",
   FTF_TRANSACTION = "ftf-transaction",
+
+  // CUSTOMER BOOKING LINK
+  FTF_CUSTOMER_BOOKING_LINK = "ftf-customerBookingLink",
 }
 
 


### PR DESCRIPTION
## Summary
Adds Customer Booking Link support to the Content Delivery system by defining the necessary entity types and interfaces.

## Changes
- Added `FTF_CUSTOMER_BOOKING_LINK` to `CDEntityType` enum
- Created `FTFCustomerBookingLink` interface extending `CDEntity`
- Added to `AllEntityField` union type for proper TypeScript support

## Technical Details
### Entity Type
- `FTF_CUSTOMER_BOOKING_LINK = "ftf-customerBookingLink"` - Follows the established naming convention

### Interface Fields
The `FTFCustomerBookingLink` interface includes:
- Core identifiers: `oid`, `tenantOID`, `bookingOID`
- Status fields: `isActive`, `expiresAt`, `isVerified`, `verifiedAt`
- Usage metrics: `accessCount`, `failedAccessCount`, `lastAccessedAt`
- Customer data: `customerEmail`, `metadata`
- Optional URLs: `qrCodeUrl`, `accessUrl`
- Audit fields: `createdAt`, `updatedAt`, `createdBy`, `updatedBy`

## Files Modified
- `src/types/entity.ts` - Added enum value
- `src/types/FirstToFly/CustomerBookingLink.ts` - New interface file
- `src/types/actions.ts` - Updated union type

This enables the main backend to implement Content Delivery Worker for customer booking links, providing frontend applications access to customer booking link data through the CD system.

🤖 Generated with [Claude Code](https://claude.ai/code)